### PR TITLE
Rename validate OTP endpoint

### DIFF
--- a/ValidateOtp/function.json
+++ b/ValidateOtp/function.json
@@ -5,7 +5,7 @@
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "route": "api/v1/merchant/cgn/otp/validate",
+      "route": "otp/validate",
       "methods": [
         "post"
       ]

--- a/ValidateOtp/index.ts
+++ b/ValidateOtp/index.ts
@@ -22,7 +22,7 @@ const app = express();
 secureExpressApp(app);
 
 // Add express route
-app.post("/api/v1/merchant/cgn/otp/validate", ValidateOtp(REDIS_CLIENT));
+app.post("/otp/validate", ValidateOtp(REDIS_CLIENT));
 
 const azureFunctionHandler = createAzureFunctionHandler(app);
 

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -11,13 +11,13 @@ info:
     This Specs are intended for all CGN operators that must integrate their e-commerce
     portal through CGN API discounts system.
 host: api.io.italia.it
-basePath: "/api/v1"
+basePath: "/api/v1/cgn/merchant"
 schemes:
   - https
 security:
   - SubscriptionKey: []
 paths:
-  "/merchant/cgn/otp/validate":
+  "/otp/validate":
     post:
       operationId: validateOtp
       summary: |


### PR DESCRIPTION
ValidateOtp endpoint has been renamed in order to be exposed through APIM with a different base path